### PR TITLE
fixed CREATE2 stack depth

### DIFF
--- a/instructions/closure.go
+++ b/instructions/closure.go
@@ -77,7 +77,7 @@ func loadClosure() {
 
 	instructionTable[opcodes.CREATE2] = opCodeInstruction{
 		action:            create2Action,
-		requireStackDepth: 2,
+		requireStackDepth: 4,
 		enabled:           true,
 		returns:           true,
 		isWriter:          true,


### PR DESCRIPTION
This PR closes issue #21 by setting stack depth of opcode `CREATE2` to `4`.